### PR TITLE
Refactor/navigation within machine

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,5 +27,5 @@
     "no-nested-ternary": 0,
     "jsx-a11y/anchor-is-valid": 0
   },
-  "ignorePatterns": [".eslintrc.json", "coverage"]
+  "ignorePatterns": [".eslintrc.json", "coverage", ".github", ".husky", "README"]
 }

--- a/src/components/contexts/authentication/AuthenticationProvider.tsx
+++ b/src/components/contexts/authentication/AuthenticationProvider.tsx
@@ -3,6 +3,7 @@ import { useHistory } from 'react-router';
 import { useInterpret } from '@xstate/react';
 import { ActorRefFrom } from 'xstate';
 import { AuthMachine } from '../../../services/domain/authentication/auth/machine/AuthMachine';
+import { navigate } from '../../helper/navigation';
 
 interface AuthenticationContextType {
   authService: ActorRefFrom<typeof AuthMachine>;
@@ -16,14 +17,16 @@ export const AuthenticationContext = createContext<AuthenticationContextType>({}
 
 export const AuthenticationProvider = ({ children }: AuthenticationProviderProps) => {
   const history = useHistory();
-  const redirect = () => history.push('/home');
+
   /**
    * To avoid multiple re render using Context Api
    * we provide a static reference to the running machines
    * that change as little as possible.
    * These service should be subscribed in consumers
    */
-  const authService = useInterpret(AuthMachine.withContext({ redirect }), { devTools: true });
+  const authService = useInterpret(AuthMachine.withConfig({ actions: { goToHomePage: () => navigate(history, '/home') } }), {
+    devTools: true
+  });
 
   return <AuthenticationContext.Provider value={{ authService }}>{children}</AuthenticationContext.Provider>;
 };

--- a/src/components/helper/navigation.ts
+++ b/src/components/helper/navigation.ts
@@ -1,0 +1,3 @@
+import { History } from 'history';
+
+export const navigate = (history: History, path: string) => history.push(path);

--- a/src/services/domain/authentication/auth/definition/AuthContext.ts
+++ b/src/services/domain/authentication/auth/definition/AuthContext.ts
@@ -4,7 +4,6 @@ import { LoginMachine } from '../../login/machine/LoginMachine';
 import { RegisterMachine } from '../../register/machine/RegisterMachine';
 
 export interface AuthContext {
-  redirect: () => void;
   loginRef?: ActorRefFrom<typeof LoginMachine>;
   registerRef?: ActorRefFrom<typeof RegisterMachine>;
   forgotRef?: ActorRefFrom<typeof ForgotMachine>;

--- a/src/services/domain/authentication/auth/machine/AuthMachineOptions.ts
+++ b/src/services/domain/authentication/auth/machine/AuthMachineOptions.ts
@@ -50,8 +50,7 @@ export const AuthMachineOptions: MachineOptions<AuthContext, AuthEvent> = {
         const token = (event as FormValidateEvent).data;
         return token;
       }
-    }),
-    goToHomePage: ({ redirect }) => redirect()
+    })
   },
   guards: {},
   activities: {},

--- a/src/services/domain/authentication/auth/test/AuthMachine.test.ts
+++ b/src/services/domain/authentication/auth/test/AuthMachine.test.ts
@@ -59,7 +59,7 @@ describe('transition to register state', () => {
 describe('auth service actions', () => {
   it('should assign the login machine ref on entering sign in', (done) => {
     const authService = interpret(
-      AuthMachine.withContext({ loginRef: undefined, registerRef: undefined, forgotRef: undefined, token: undefined, redirect: jest.fn() })
+      AuthMachine.withContext({ loginRef: undefined, registerRef: undefined, forgotRef: undefined, token: undefined })
     ).onTransition((state) => {
       if (state.matches(AuthStates.Login)) {
         expect(state.context.loginRef).not.toBeUndefined();
@@ -73,7 +73,7 @@ describe('auth service actions', () => {
   });
   it('should assign the register machine ref on entering register', (done) => {
     const authService = interpret(
-      AuthMachine.withContext({ loginRef: undefined, registerRef: undefined, forgotRef: undefined, token: undefined, redirect: jest.fn() })
+      AuthMachine.withContext({ loginRef: undefined, registerRef: undefined, forgotRef: undefined, token: undefined })
     ).onTransition((state) => {
       if (state.matches(AuthStates.Register)) {
         expect(state.context.registerRef).not.toBeUndefined();
@@ -88,7 +88,7 @@ describe('auth service actions', () => {
   });
   it('should assign the forgot machine ref on entering forgot', (done) => {
     const authService = interpret(
-      AuthMachine.withContext({ loginRef: undefined, registerRef: undefined, forgotRef: undefined, token: undefined, redirect: jest.fn() })
+      AuthMachine.withContext({ loginRef: undefined, registerRef: undefined, forgotRef: undefined, token: undefined })
     ).onTransition((state) => {
       if (state.matches(AuthStates.Forgot)) {
         expect(state.context.forgotRef).not.toBeUndefined();
@@ -103,7 +103,7 @@ describe('auth service actions', () => {
   });
   it('should assign the token on validate event', (done) => {
     const authService = interpret(
-      AuthMachine.withContext({ loginRef: undefined, registerRef: undefined, forgotRef: undefined, token: undefined, redirect: jest.fn() })
+      AuthMachine.withContext({ loginRef: undefined, registerRef: undefined, forgotRef: undefined, token: undefined })
     ).onTransition((state) => {
       if (state.matches(AuthStates.Authenticated)) {
         expect(state.context.token).not.toBeUndefined();


### PR DESCRIPTION
Machine context should not hold not serializable value like a function. With this pattern we keep the business logic and the interface separated (therefore the machine does not depend on the ui framework)